### PR TITLE
Respect the official naming convention

### DIFF
--- a/getting_started.md
+++ b/getting_started.md
@@ -9,7 +9,7 @@ nav_order: 2
 
 The main JupyterHub server can be reached at [jupyterhub.hpc.kuleuven.be](
 https://jupyterhub.hpc.kuleuven.be). You will be asked to authenticate with
-your central KULeuven credentials.
+your central KU Leuven credentials.
 
 ### Temporary VSC accounts
 

--- a/index.md
+++ b/index.md
@@ -5,7 +5,7 @@ nav_order: 1
 
 ## Welcome to the JupyterHub service documentation!
 
-This website describes how KULeuven users may employ the JupyterHub service.
+This website describes how KU Leuven users may employ the JupyterHub service.
 
 If you have an active VSC account, have a look at the [Getting started](
 ./getting_started) page. Also the [What is Jupyter](


### PR DESCRIPTION
E.g. <https://vrttaal.net/taaladvies-spelling/ku-leuven>